### PR TITLE
Disable files permissions callback on CLI

### DIFF
--- a/src/EventListener/DataContainer/FilesPermissionsCallback.php
+++ b/src/EventListener/DataContainer/FilesPermissionsCallback.php
@@ -30,6 +30,10 @@ class FilesPermissionsCallback
 
     public function __invoke(): void
     {
+        if ('cli' === \PHP_SAPI) {
+            return;
+        }
+
         $user = $this->security->getUser();
 
         if (!$user instanceof BackendUser) {


### PR DESCRIPTION
While running the command `contao:migrate` on CLI after the installation of the bundle, following error occured:

```
In FilesPermissionsCallback.php line 36:
                             
  Unexpected user instance. 
```

This PR fixes the callback and skips the permission check on CLI completely.