### PR TITLE
fix: Add `tl_message_queue` to ignored database tables

### DIFF
--- a/src/Provider/AbstractDatabaseProvider.php
+++ b/src/Provider/AbstractDatabaseProvider.php
@@ -22,7 +22,7 @@ use Doctrine\DBAL\Schema\Exception\TableDoesNotExist;
  */
 abstract class AbstractDatabaseProvider implements FileUsageProviderInterface
 {
-    private const IGNORE_TABLES = ['tl_version', 'tl_log', 'tl_undo', 'tl_search_index'];
+    private const IGNORE_TABLES = ['tl_version', 'tl_log', 'tl_undo', 'tl_search_index','tl_message_queue'];
 
     private AbstractSchemaManager|null $schemaManager = null;
 


### PR DESCRIPTION
Finding new file usages can consume a significant amount of memory. This is caused by the tl_message_queue table, which can grow very large if many message processing attempts fail.

The tl_message_queue table never contains file references, so scanning it for file usages is unnecessary. This change excludes the table from the file usage search, reducing memory consumption and improving performance without affecting the results.