### PR TITLE
Update inserttag pattern

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,12 +46,18 @@
             "InspiredMinds\\ContaoFileUsage\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "InspiredMinds\\ContaoFileUsage\\Tests\\": "tests/"
+        }
+    },
     "extra": {
         "contao-manager-plugin": "InspiredMinds\\ContaoFileUsage\\ContaoManager\\Plugin"
     },
     "require-dev": {
         "contao/easy-coding-standard": "^6.0",
         "contao/rector": "^1.0",
+        "phpunit/phpunit": "^11.0",
         "shipmonk/composer-dependency-analyser": "^1.4"
     },
     "config": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         failOnWarning="true"
+         failOnRisky="true"
+>
+    <testsuites>
+        <testsuite name="Contao File Usage">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/InsertTag/InsertTagParser.php
+++ b/src/InsertTag/InsertTagParser.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Contao File Usage extension.
+ *
+ * (c) INSPIRED MINDS
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace InspiredMinds\ContaoFileUsage\InsertTag;
+
+/**
+ * Central definition for detecting file references through Contao insert tags.
+ *
+ * Any insert tag whose first parameter is a Contao file UUID references that file - regardless of the
+ * tag name (file, picture, figure, image, svg or custom tags like foo_bar, ...) and regardless of any
+ * following parameters (which may even span multiple lines). Providers (database, file system,
+ * MetaModels, ...) should rely on this pattern instead of hard-coding their own.
+ */
+final class InsertTagParser
+{
+    // phpcs:disable
+    public const PATTERN = '~{{[a-z0-9_]+::([a-f0-9]{8}-[a-f0-9]{4}-1[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})[^}]*}}~';
+    // phpcs:enable
+
+    /**
+     * Extracts all file UUIDs referenced through insert tags in the given content.
+     *
+     * @return list<string>
+     */
+    public static function extractUuids(string $content): array
+    {
+        if (!preg_match_all(self::PATTERN, $content, $matches)) {
+            return [];
+        }
+
+        return $matches[1];
+    }
+}

--- a/src/InsertTag/InsertTagParser.php
+++ b/src/InsertTag/InsertTagParser.php
@@ -22,9 +22,7 @@ namespace InspiredMinds\ContaoFileUsage\InsertTag;
  */
 final class InsertTagParser
 {
-    // phpcs:disable
     public const PATTERN = '~{{[a-z0-9_]+::([a-f0-9]{8}-[a-f0-9]{4}-1[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})[^}]*}}~';
-    // phpcs:enable
 
     /**
      * Extracts all file UUIDs referenced through insert tags in the given content.

--- a/src/Provider/DatabaseProvider.php
+++ b/src/Provider/DatabaseProvider.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\FilesModel;
 use Contao\StringUtil;
 use Contao\Validator;
+use InspiredMinds\ContaoFileUsage\InsertTag\InsertTagParser;
 use InspiredMinds\ContaoFileUsage\Result\DatabaseInsertTagResult;
 use InspiredMinds\ContaoFileUsage\Result\FileTreeMultipleResult;
 use InspiredMinds\ContaoFileUsage\Result\ResultsCollection;
@@ -27,8 +28,6 @@ use InspiredMinds\ContaoFileUsage\Result\ResultsCollection;
  */
 class DatabaseProvider extends AbstractDatabaseProvider
 {
-    private const INSERT_TAG_PATTERN = '~{{(file|picture|figure)::([a-f0-9]{8}-[a-f0-9]{4}-1[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})((\||\?)[^}]+)?}}~';
-
     public function __construct(
         private readonly ResourceFinder $resourceFinder,
         private readonly ContaoFramework $framework,
@@ -146,10 +145,8 @@ class DatabaseProvider extends AbstractDatabaseProvider
                 continue;
             }
 
-            if (preg_match_all(self::INSERT_TAG_PATTERN, $data, $matches)) {
-                foreach ($matches[2] ?? [] as $uuid) {
-                    $collection->addResult($uuid, new DatabaseInsertTagResult($table, $field, $id, $pk));
-                }
+            foreach (InsertTagParser::extractUuids($data) as $uuid) {
+                $collection->addResult($uuid, new DatabaseInsertTagResult($table, $field, $id, $pk));
             }
         }
     }

--- a/tests/InsertTag/InsertTagParserTest.php
+++ b/tests/InsertTag/InsertTagParserTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Contao File Usage extension.
+ *
+ * (c) INSPIRED MINDS
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace InspiredMinds\ContaoFileUsage\Tests\InsertTag;
+
+use InspiredMinds\ContaoFileUsage\InsertTag\InsertTagParser;
+use PHPUnit\Framework\TestCase;
+
+class InsertTagParserTest extends TestCase
+{
+    private const UUID = '58ca4a90-2d30-11e4-8c21-0800200c9a66';
+
+    /**
+     * @dataProvider provideContentWithSingleReference
+     */
+    public function testExtractsTheUuidFromAnyInsertTag(string $content): void
+    {
+        $this->assertSame([self::UUID], InsertTagParser::extractUuids($content));
+    }
+
+    public static function provideContentWithSingleReference(): iterable
+    {
+        yield 'file without parameters' => ['{{file::'.self::UUID.'}}'];
+        yield 'image with parameters' => ['{{image::'.self::UUID.'?width=200&height=150}}'];
+        yield 'picture with template' => ['{{picture::'.self::UUID.'?size=1&template=picture_default}}'];
+        yield 'svg with class' => ['{{svg::'.self::UUID.'?height=80&class=custom-icon}}'];
+        yield 'custom tag with underscore' => ['{{foo_bar::'.self::UUID.'?height=80&class=custom-icon}}'];
+        yield 'legacy pipe parameters' => ['{{file::'.self::UUID.'|urlattr}}'];
+        yield 'additional colon segment' => ['{{svg::'.self::UUID.'::my-class}}'];
+        yield 'surrounded by other content' => ['lorem {{image::'.self::UUID.'?width=1}} ipsum'];
+        yield 'multi-line figure with bracket parameters' => [
+            "{{figure::".self::UUID."?\n"
+            ."size=1&\n"
+            ."metadata[title]=Mein%20Bild&\n"
+            ."enableLightbox=1&\n"
+            ."options[attr][class]=main_figure&\n"
+            ."template=image\n"
+            .'}}',
+        ];
+    }
+
+    public function testExtractsAllReferencesInOrder(): void
+    {
+        $content = '{{file::'.self::UUID.'}} some text '
+            .'{{svg::a8824458-a08e-11e9-9d96-81cb79fa7a74?height=80}}';
+
+        $this->assertSame(
+            [self::UUID, 'a8824458-a08e-11e9-9d96-81cb79fa7a74'],
+            InsertTagParser::extractUuids($content),
+        );
+    }
+
+    /**
+     * @dataProvider provideContentWithoutReference
+     */
+    public function testReturnsNoUuidForNonFileReferences(string $content): void
+    {
+        $this->assertSame([], InsertTagParser::extractUuids($content));
+    }
+
+    public static function provideContentWithoutReference(): iterable
+    {
+        yield 'empty string' => [''];
+        yield 'plain text' => ['Just some text without any insert tag.'];
+        yield 'numeric id parameter' => ['{{link_url::123}}'];
+        yield 'non-uuid parameter' => ['{{insert_article::an-alias}}'];
+        yield 'uppercase tag name' => ['{{FILE::'.self::UUID.'}}'];
+        yield 'malformed uuid' => ['{{file::not-a-uuid}}'];
+    }
+}


### PR DESCRIPTION
Update the inserttag pattern to support more tag variants

Centralized storage of the pattern for access by, for example, external services (e.g., https://metamodels.readthedocs.io/de/latest/manual/extended/file-usage.html)